### PR TITLE
Remove isomorphic-fetch from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,12 @@ To use it, wrap the standard Redux store with it. Here is an example setup. For 
 
 ```js
 import { createStore, applyMiddleware, combineReducers } from 'redux';
-import { apiMiddleware } from 'redux-api-middleware';
+import { apiMiddlewareCreator } from 'redux-api-middleware';
 import reducers from './reducers';
 
-const reducer = combineReducers(reducers);
+const apiMiddleware = apiMiddlewareCreator(fetch);
 const createStoreWithMiddleware = applyMiddleware(apiMiddleware)(createStore);
+const reducer = combineReducers(reducers);
 
 export default function configureStore(initialState) {
   return createStoreWithMiddleware(reducer, initialState);
@@ -137,7 +138,7 @@ It must be one of the strings `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE` or
 
 The body of the API call.
 
-`redux-api-middleware` uses [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) to make the API call. `[CALL_API].body` should hence be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
+`redux-api-middleware` uses [`fetch`](https://fetch.spec.whatwg.org) to make the API call. `[CALL_API].body` should hence be a valid body according to the the fetch specification. In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
 
 #### `[CALL_API].headers`
 
@@ -193,7 +194,7 @@ The `[CALL_API].types` property controls the output of `redux-api-middleware`. T
 
   But errors may pop up at this stage, for several reasons:
   - `redux-api-middleware` has to call those of `[CALL_API].bailout`, `[CALL_API].endpoint` and `[CALL_API].headers` that happen to be a function, which may throw an error;
-  - `isomorphic-fetch` may throw an error: the RSAA definition is not strong enough to preclude that from happening (you may, for example, send in a `[CALL_API].body` that is not valid according to the fetch specification &mdash; mind the SHOULDs in the [RSAA definition](#redux-standard-api-calling-actions));
+  - `fetch` may throw an error: the RSAA definition is not strong enough to preclude that from happening (you may, for example, send in a `[CALL_API].body` that is not valid according to the fetch specification &mdash; mind the SHOULDs in the [RSAA definition](#redux-standard-api-calling-actions));
   - a network failure occurs (the network is unreachable, the server responds with an error,...).
 
   If such an error occurs, a different *request* FSA will be dispatched (*instead* of the one described above). It will contain the following properties:
@@ -400,9 +401,9 @@ The following objects are exported by `redux-api-middleware`.
 
 A JavaScript `Symbol` whose presence as a key in an action signals that `redux-api-middleware` should process said action.
 
-#### `apiMiddleware`
+#### `apiMiddlewareCreator`
 
-The Redux middleware itself.
+A function that returns the Redux middleware.
 
 #### `isRSAA(action)`
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^5.8.25",
-    "isomorphic-fetch": "^2.1.1",
-    "lodash.isfunction": "^3.0.8",
     "lodash.isplainobject": "^3.2.0"
   },
   "devDependencies": {
@@ -38,6 +36,7 @@
     "coveralls": "^2.11.4",
     "eslint": "^1.6.0",
     "eslint-plugin-babel": "^2.1.1",
+    "isomorphic-fetch": "^2.2.1",
     "nock": "^2.15.0",
     "normalizr": "^1.1.0",
     "rimraf": "^2.4.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 /**
  * Redux middleware for calling an API
  * @module redux-api-middleware
- * @requires isomorphic-fetch
  * @requires lodash.isplainobject
  * @exports {symbol} CALL_API
  * @exports {function} isRSAA
@@ -33,7 +32,7 @@ import CALL_API from './CALL_API';
 import { isRSAA, validateRSAA, isValidRSAA } from './validation';
 import { InvalidRSAA, InternalError, RequestError, ApiError } from './errors';
 import { getJSON } from './util';
-import { apiMiddleware } from './middleware';
+import { apiMiddlewareCreator } from './middleware';
 
 export {
   CALL_API,
@@ -45,5 +44,5 @@ export {
   RequestError,
   ApiError,
   getJSON,
-  apiMiddleware
+  apiMiddlewareCreator
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,142 +1,132 @@
-import isomorphicFetch from 'isomorphic-fetch';
-import isPlainObject from 'lodash.isplainobject';
-import isFunction from 'lodash.isfunction';
-
 import CALL_API from './CALL_API';
 import { isRSAA, validateRSAA } from './validation';
 import { InvalidRSAA, RequestError, ApiError } from './errors' ;
 import { getJSON, normalizeTypeDescriptors, actionWith } from './util';
 
 /**
- * A Redux middleware that processes RSAA actions.
+ * A function that returns a Redux middleware to processe RSAA actions.
  *
  * @type {ReduxMiddleware}
  * @access public
  */
-let fetch = isomorphicFetch;
-function apiMiddleware(storeOrFetch) {
-  if (isFunction(storeOrFetch)) {
-    fetch = storeOrFetch;
-    return apiMiddleware;
-  }
-  const { getState } = storeOrFetch;
 
-  return (next) => async (action) => {
-    // Do not process actions without a [CALL_API] property
-    if (!isRSAA(action)) {
-      return next(action);
-    }
-
-    // Try to dispatch an error request FSA for invalid RSAAs
-    const validationErrors = validateRSAA(action);
-    if (validationErrors.length) {
-      const callAPI = action[CALL_API];
-      if (callAPI.types && Array.isArray(callAPI.types)) {
-        let requestType = callAPI.types[0];
-        if (requestType && requestType.type) {
-          requestType = requestType.type;
-        }
-        next({
-          type: requestType,
-          payload: new InvalidRSAA(validationErrors),
-          error: true
-        });
+export function apiMiddlewareCreator(fetch) {
+  return ({ getState }) => {
+    return (next) => async (action) => {
+      // Do not process actions without a [CALL_API] property
+      if (!isRSAA(action)) {
+        return next(action);
       }
-      return;
-    }
 
-    // Parse the validated RSAA action
-    const callAPI = action[CALL_API];
-    var { endpoint, headers } = callAPI;
-    const { method, body, credentials, bailout, types } = callAPI;
-    const [requestType, successType, failureType] = normalizeTypeDescriptors(types);
-
-    // Should we bail out?
-    try {
-      if ((typeof bailout === 'boolean' && bailout) ||
-          (typeof bailout === 'function' && bailout(getState()))) {
+      // Try to dispatch an error request FSA for invalid RSAAs
+      const validationErrors = validateRSAA(action);
+      if (validationErrors.length) {
+        const callAPI = action[CALL_API];
+        if (callAPI.types && Array.isArray(callAPI.types)) {
+          let requestType = callAPI.types[0];
+          if (requestType && requestType.type) {
+            requestType = requestType.type;
+          }
+          next({
+            type: requestType,
+            payload: new InvalidRSAA(validationErrors),
+            error: true
+          });
+        }
         return;
       }
-    } catch (e) {
-      return next(await actionWith(
-        {
-          ...requestType,
-          payload: new RequestError('[CALL_API].bailout function failed'),
-          error: true
-        },
-        [action, getState()]
-      ));
-    }
 
-    // Process [CALL_API].endpoint function
-    if (typeof endpoint === 'function') {
+      // Parse the validated RSAA action
+      const callAPI = action[CALL_API];
+      var { endpoint, headers } = callAPI;
+      const { method, body, credentials, bailout, types } = callAPI;
+      const [requestType, successType, failureType] = normalizeTypeDescriptors(types);
+
+      // Should we bail out?
       try {
-        endpoint = endpoint(getState());
+        if ((typeof bailout === 'boolean' && bailout) ||
+            (typeof bailout === 'function' && bailout(getState()))) {
+          return;
+        }
       } catch (e) {
         return next(await actionWith(
           {
             ...requestType,
-            payload: new RequestError('[CALL_API].endpoint function failed'),
+            payload: new RequestError('[CALL_API].bailout function failed'),
             error: true
           },
           [action, getState()]
         ));
       }
-    }
 
-    // Process [CALL_API].headers function
-    if (typeof headers === 'function') {
+      // Process [CALL_API].endpoint function
+      if (typeof endpoint === 'function') {
+        try {
+          endpoint = endpoint(getState());
+        } catch (e) {
+          return next(await actionWith(
+            {
+              ...requestType,
+              payload: new RequestError('[CALL_API].endpoint function failed'),
+              error: true
+            },
+            [action, getState()]
+          ));
+        }
+      }
+
+      // Process [CALL_API].headers function
+      if (typeof headers === 'function') {
+        try {
+          headers = headers(getState());
+        } catch (e) {
+          return next(await actionWith(
+            {
+              ...requestType,
+              payload: new RequestError('[CALL_API].headers function failed'),
+              error: true
+            },
+            [action, getState()]
+          ));
+        }
+      }
+
+      // We can now dispatch the request FSA
+      next(await actionWith(
+        requestType,
+        [action, getState()]
+      ));
+
       try {
-        headers = headers(getState());
-      } catch (e) {
+        // Make the API call
+        var res = await fetch(endpoint, { method, body, credentials, headers });
+      } catch(e) {
+        // The request was malformed, or there was a network error
         return next(await actionWith(
           {
             ...requestType,
-            payload: new RequestError('[CALL_API].headers function failed'),
+            payload: new RequestError(e.message),
             error: true
           },
           [action, getState()]
         ));
       }
-    }
 
-    // We can now dispatch the request FSA
-    next(await actionWith(
-      requestType,
-      [action, getState()]
-    ));
-
-    try {
-      // Make the API call
-      var res = await fetch(endpoint, { method, body, credentials, headers });
-    } catch(e) {
-      // The request was malformed, or there was a network error
-      return next(await actionWith(
-        {
-          ...requestType,
-          payload: new RequestError(e.message),
-          error: true
-        },
-        [action, getState()]
-      ));
-    }
-
-    // Process the server response
-    if (res.ok) {
-      return next(await actionWith(
-        successType,
-        [action, getState(), res]
-      ));
-    } else {
-      return next(await actionWith(
-        {
-          ...failureType,
-          error: true
-        },
-        [action, getState(), res]
-      ));
+      // Process the server response
+      if (res.ok) {
+        return next(await actionWith(
+          successType,
+          [action, getState(), res]
+        ));
+      } else {
+        return next(await actionWith(
+          {
+            ...failureType,
+            error: true
+          },
+          [action, getState(), res]
+        ));
+      }
     }
   }
 }
-
-export { apiMiddleware };

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,15 @@
 import test from 'tape';
 import { Schema, normalize, arrayOf } from 'normalizr';
 import nock from 'nock';
+import fetch from 'isomorphic-fetch';
 
 import CALL_API from '../src/CALL_API';
 import { isRSAA, isValidTypeDescriptor, validateRSAA, isValidRSAA } from '../src/validation';
 import { InvalidRSAA, InternalError, RequestError, ApiError } from '../src/errors';
 import { getJSON, normalizeTypeDescriptors, actionWith } from '../src/util';
-import { apiMiddleware } from '../src/middleware';
+import { apiMiddlewareCreator } from '../src/middleware';
+
+const apiMiddleware = apiMiddlewareCreator(fetch);
 
 test('isRSAA must identify RSAAs', (t) => {
   const action1 = '';
@@ -1657,66 +1660,6 @@ test('apiMiddleware must dispatch a failure FSA on an unsuccessful API call with
       break;
     }
   };
-  const actionHandler = nextHandler(doNext);
-
-  t.plan(8);
-  actionHandler(anAction);
-});
-
-test('apiMiddleware must allow fetch to be passed in', (t) => {
-  const anAction = {
-    [CALL_API]: {
-      endpoint: 'http://127.0.0.1/api/users/1',
-      method: 'GET',
-      types: ['REQUEST', 'SUCCESS', 'FAILURE'],
-      body: {
-        some: 'arbitrary JSON'
-      },
-      credentials: 'include',
-      headers: {
-        'X-Testing-Header': 'yeah'
-      }
-    }
-  };
-  const mockFetch = (endpoint, { method, body, credentials, headers }) => {
-    t.pass('apiMiddleware executed the passed-in fetch');
-    t.equal(
-      endpoint,
-      'http://127.0.0.1/api/users/1',
-      'passed-in fetch executed with proper endpoint'
-    );
-    t.equal(
-      method,
-      'GET',
-      'passed-in fetch executed with proper method'
-    );
-    t.deepEqual(
-      body,
-      { some: 'arbitrary JSON' },
-      'passed-in fetch executed with proper body'
-    );
-    t.equal(
-      credentials,
-      'include',
-      'passed-in fetch executed with proper credentials'
-    );
-    t.deepEqual(
-      headers,
-      { 'X-Testing-Header': 'yeah' },
-      'passed-in fetch executed with proper headers'
-    );
-    return Promise.resolve({
-      ok: true,
-      status: 404,
-      headers: { 'Content-Type': 'application/json' },
-      json: Promise.resolve({ more: 'mocks' }),
-    });
-  };
-  const doNext = (action) => {
-    t.pass('apiMiddleware with custom fetch executed next state');
-  };
-  const doGetState = () => {};
-  const nextHandler = apiMiddleware(mockFetch)({ getState: doGetState });
   const actionHandler = nextHandler(doNext);
 
   t.plan(8);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,7 +1364,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -1592,10 +1592,6 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.isfunction@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz#4db709fc81bc4a8fd7127a458a5346c5cdce2c6b"
 
 lodash.isplainobject@^3.0.0, lodash.isplainobject@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This PR adds `apiMiddlewareCreator` that returns the Redux middleware.
It allows

* the library to remove `isomorphic-fetch` from the dependencies
* developers to use any `fetch` implementation

Since `apiMiddleware` API is no longer needed, it is removed in the PR.